### PR TITLE
Updated formatting in snippets

### DIFF
--- a/coffee/blocks/after.sublime-snippet
+++ b/coffee/blocks/after.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 after ->
-  $1
+	$1
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>after</tabTrigger>

--- a/coffee/blocks/aftereach.sublime-snippet
+++ b/coffee/blocks/aftereach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 afterEach ->
-  $1
+	$1
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>afte</tabTrigger>

--- a/coffee/blocks/before.sublime-snippet
+++ b/coffee/blocks/before.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 before ->
-  $1
+	$1
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>bef</tabTrigger>

--- a/coffee/blocks/beforeeach.sublime-snippet
+++ b/coffee/blocks/beforeeach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 beforeEach ->
-  $1
+	$1
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>befe</tabTrigger>

--- a/coffee/blocks/describe.sublime-snippet
+++ b/coffee/blocks/describe.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 describe "${1:suite}", ->
-  $2
+	$2
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>des</tabTrigger>

--- a/coffee/blocks/it.sublime-snippet
+++ b/coffee/blocks/it.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 it "${1:expectation}", ->
-  $2
+	$2
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->
     <tabTrigger>it</tabTrigger>

--- a/js/blocks/after.sublime-snippet
+++ b/js/blocks/after.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-after(function(){
-  $1
+after(function () {
+	$1
 });$0
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->

--- a/js/blocks/aftereach.sublime-snippet
+++ b/js/blocks/aftereach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-afterEach(function(){
-  $1
+afterEach(function () {
+	$1
 });$0
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->

--- a/js/blocks/before.sublime-snippet
+++ b/js/blocks/before.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-before(function(){
-  $1
+before(function () {
+	$1
 });$0
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->

--- a/js/blocks/beforeeach.sublime-snippet
+++ b/js/blocks/beforeeach.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-beforeEach(function(){
-  $1
+beforeEach(function () {
+	$1
 });$0
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->

--- a/js/blocks/describe.sublime-snippet
+++ b/js/blocks/describe.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-describe('${1:suite}', function() {
-  $2
+describe('${1:suite}', function () {
+	$2
 });$0
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->

--- a/js/blocks/it.sublime-snippet
+++ b/js/blocks/it.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
-it('${1:expectation}', function() {
-  $2
+it('${1:expectation}', function () {
+	$2
 });
 ]]></content>
     <!-- Optional: Tab trigger to activate the snippet -->


### PR DESCRIPTION
Use tabs for indentation instead of spaces since it will work for everyone (it will be converted to spaces when you insert the snippet if needed). Function invocations should pass JSHint.
